### PR TITLE
Add Rust, TypeScript, and bun to working with section

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@
 <a href="https://code.visualstudio.com/"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/vscode/vscode-original.svg" alt="vscode" width="40" height="40"/></a>
 <a href="https://www.gnu.org/software/emacs/"><img src="https://upload.wikimedia.org/wikipedia/commons/0/08/EmacsIcon.svg" alt="emacs" width="40" height="40"/></a>
 
+<a href="https://www.rust-lang.org/"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/rust/rust-original.svg" alt="rust" width="40" height="40"/></a>
+<a href="https://www.typescriptlang.org/"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" alt="typescript" width="40" height="40"/></a>
+<a href="https://bun.sh/"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/bun/bun-original.svg" alt="bun" width="40" height="40"/></a>
+
 ## 💼 Working on:
 
 <p align="left">


### PR DESCRIPTION
## Summary
Added a second line to the 'Working with' section featuring:
- Rust programming language
- TypeScript  
- Bun runtime

These technologies complement the existing VSCode and Emacs tools in the first line.

## Test plan
- [x] Verified the README renders correctly with the new icons
- [x] Confirmed all technology icons are properly linked and displayed

🤖 Generated with [Pochi](https://getpochi.com)